### PR TITLE
Fix pub get not resolving bridge on --dev

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
   bridge: 
     git:
       url: https://github.com/dart-bridge/framework
-      ref: feature/chalk-templates
+      ref: develop
 dev_dependencies:
   test: any
   grinder: any


### PR DESCRIPTION
```
Resolving dependencies...
Git error. Command: git rev-list --max-count=1 feature/chalk-templates
fatal: ambiguous argument 'feature/chalk-templates': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```
